### PR TITLE
add utm link killer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
 # Ideas
 
 - Some way to disable these behaviours/scripts for certain sites
-- Remove utm crap from links

--- a/manifest.json
+++ b/manifest.json
@@ -44,7 +44,8 @@
         "amp_link_killer.js",
         "overflow_hidden_killer.js",
         "meta_f_unabuser.js",
-        "copy_unabuser.js"
+        "copy_unabuser.js",
+        "utm_link_killer.js"
       ]
     }
   ]

--- a/utm_link_killer.js
+++ b/utm_link_killer.js
@@ -1,0 +1,21 @@
+(() => {
+  const anchors = Array.from(document.querySelectorAll('a[href]'));
+  anchors.forEach(anchor => {
+    try {
+      const url = new URL(anchor.href);
+      const params = url.searchParams;
+      let changed = false;
+      Array.from(params.keys()).forEach(key => {
+        if (key.toLowerCase().startsWith('utm_')) {
+          params.delete(key);
+          changed = true;
+        }
+      });
+      if (changed) {
+        anchor.href = url.toString();
+      }
+    } catch (_) {
+      // ignore invalid URLs
+    }
+  });
+})();


### PR DESCRIPTION
## Summary
- strip `utm_*` query parameters from all links via new `utm_link_killer.js`
- wire up the script in the manifest for all sites
- drop fulfilled idea about removing utm parameters from README

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a53a408f74832fb96c3b11d74bb042