### PR TITLE
Add configurable auto refresh

### DIFF
--- a/auto_refresh.js
+++ b/auto_refresh.js
@@ -1,15 +1,19 @@
 (() => {
   let refreshIntervalMinutes = 0;
   let timeoutId;
+  let nextRefreshTime = 0;
 
   const resetTimer = () => {
     if (timeoutId) {
       clearTimeout(timeoutId);
     }
     if (refreshIntervalMinutes > 0) {
+      nextRefreshTime = Date.now() + refreshIntervalMinutes * 60 * 1000;
       timeoutId = setTimeout(() => {
         location.reload();
-      }, refreshIntervalMinutes * 60 * 1000);
+      }, nextRefreshTime - Date.now());
+    } else {
+      nextRefreshTime = 0;
     }
   };
 
@@ -23,6 +27,17 @@
   ['click', 'mousemove', 'keydown', 'scroll', 'touchstart'].forEach((event) => {
     window.addEventListener(event, resetTimer, true);
   });
+
+  if (chrome.runtime && chrome.runtime.onMessage) {
+    chrome.runtime.onMessage.addListener((request, _sender, sendResponse) => {
+      if (request.type === 'getRemaining') {
+        sendResponse({
+          remainingMs: nextRefreshTime ? nextRefreshTime - Date.now() : 0,
+          refreshIntervalMinutes,
+        });
+      }
+    });
+  }
 
   if (chrome.storage && chrome.storage.onChanged) {
     chrome.storage.onChanged.addListener((changes, area) => {

--- a/auto_refresh.js
+++ b/auto_refresh.js
@@ -1,0 +1,37 @@
+(() => {
+  let refreshIntervalMinutes = 0;
+  let timeoutId;
+
+  const resetTimer = () => {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+    if (refreshIntervalMinutes > 0) {
+      timeoutId = setTimeout(() => {
+        location.reload();
+      }, refreshIntervalMinutes * 60 * 1000);
+    }
+  };
+
+  const loadInterval = () => {
+    chrome.storage.sync.get({ refreshIntervalMinutes: 0 }, (data) => {
+      refreshIntervalMinutes = data.refreshIntervalMinutes || 0;
+      resetTimer();
+    });
+  };
+
+  ['click', 'mousemove', 'keydown', 'scroll', 'touchstart'].forEach((event) => {
+    window.addEventListener(event, resetTimer, true);
+  });
+
+  if (chrome.storage && chrome.storage.onChanged) {
+    chrome.storage.onChanged.addListener((changes, area) => {
+      if (area === 'sync' && changes.refreshIntervalMinutes) {
+        refreshIntervalMinutes = changes.refreshIntervalMinutes.newValue || 0;
+        resetTimer();
+      }
+    });
+  }
+
+  loadInterval();
+})();

--- a/manifest.json
+++ b/manifest.json
@@ -45,7 +45,8 @@
         "overflow_hidden_killer.js",
         "meta_f_unabuser.js",
         "copy_unabuser.js",
-        "utm_link_killer.js"
+        "utm_link_killer.js",
+        "auto_refresh.js"
       ]
     }
   ]

--- a/popup.html
+++ b/popup.html
@@ -6,14 +6,19 @@
       body {
         min-width: 230px;
         font-family: sans-serif;
+        padding: 10px;
       }
       form {
         display: flex;
         flex-direction: column;
-        gap: 8px;
+        gap: 10px;
+      }
+      label {
+        display: flex;
+        flex-direction: column;
+        gap: 5px;
       }
       input[type="number"] {
-        width: 100%;
         padding: 6px;
         border: 1px solid #ccc;
         border-radius: 4px;

--- a/popup.html
+++ b/popup.html
@@ -1,42 +1,32 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Popup</title>
+    <title>Auto Refresh Settings</title>
     <style>
-      *  {
-        box-sizing: border-box;
-      }
       body {
         min-width: 230px;
+        font-family: sans-serif;
       }
-       input.domain {
+      label {
+        display: flex;
+        flex-direction: column;
+      }
+      input[type="number"] {
         width: 100%;
         padding: 6px;
         border: 1px solid #ccc;
-        border-radius: 6px;
-        margin-bottom: 6px;
-      }
-      .settings label {
-        display: flex;
-        align-items: center;
-      }
-      .settings label input {
-        margin-right: 6px;
+        border-radius: 4px;
+        margin-top: 4px;
       }
     </style>
   </head>
   <body>
-
-    <input class="domain" disabled value="domain" />
     <form id="settings">
-      <div class="settings">
-        <label>
-          <input type="checkbox" name="overflow_hidden_killer_disabled" />
-          Disable overflow hidden killer
-        </label>
-      </div>
+      <label>
+        Refresh interval (minutes)
+        <input type="number" id="refresh-interval" min="0" />
+      </label>
     </form>
-
     <script src="popup.js"></script>
   </body>
 </html>

--- a/popup.html
+++ b/popup.html
@@ -7,26 +7,41 @@
         min-width: 230px;
         font-family: sans-serif;
       }
-      label {
+      form {
         display: flex;
         flex-direction: column;
+        gap: 8px;
       }
       input[type="number"] {
         width: 100%;
         padding: 6px;
         border: 1px solid #ccc;
         border-radius: 4px;
+      }
+      button {
+        padding: 6px;
+        border: none;
+        background-color: #f44336;
+        color: #fff;
+        border-radius: 4px;
+        cursor: pointer;
+      }
+      #countdown {
         margin-top: 4px;
+        font-size: 0.9em;
+        color: #555;
       }
     </style>
   </head>
   <body>
     <form id="settings">
       <label>
-        Refresh interval (minutes)
-        <input type="number" id="refresh-interval" min="0" />
+        Refresh interval (minutes, min 1)
+        <input type="number" id="refresh-interval" min="1" placeholder="Not active" />
       </label>
+      <button type="button" id="disable">Disable refresh</button>
     </form>
+    <p id="countdown"></p>
     <script src="popup.js"></script>
   </body>
 </html>

--- a/popup.js
+++ b/popup.js
@@ -1,13 +1,16 @@
 (() => {
+  const input = document.getElementById('refresh-interval');
 
-  const settingsFormEl = document.getElementById('settings');
-  settingsFormEl.addEventListener('change', function (ev) {
-    console.log(ev.target.name, ev.target.checked);
+  chrome.storage.sync.get({ refreshIntervalMinutes: 0 }, (data) => {
+    if (data.refreshIntervalMinutes) {
+      input.value = data.refreshIntervalMinutes;
+    }
   });
 
-  chrome.tabs.query({active: true, currentWindow: true}, (tabs) => {
-    // tabs[0] is the active tab in the current window
-    // let url = tabs[0].url;
+  input.addEventListener('change', () => {
+    const minutes = parseInt(input.value, 10);
+    chrome.storage.sync.set({
+      refreshIntervalMinutes: isNaN(minutes) ? 0 : minutes,
+    });
   });
-
 })();

--- a/popup.js
+++ b/popup.js
@@ -1,5 +1,7 @@
 (() => {
   const input = document.getElementById('refresh-interval');
+  const disableBtn = document.getElementById('disable');
+  const countdownEl = document.getElementById('countdown');
 
   chrome.storage.sync.get({ refreshIntervalMinutes: 0 }, (data) => {
     if (data.refreshIntervalMinutes) {
@@ -7,10 +9,42 @@
     }
   });
 
-  input.addEventListener('change', () => {
+  const save = () => {
     const minutes = parseInt(input.value, 10);
     chrome.storage.sync.set({
-      refreshIntervalMinutes: isNaN(minutes) ? 0 : minutes,
+      refreshIntervalMinutes: isNaN(minutes) ? 0 : Math.max(1, minutes),
     });
+  };
+
+  input.addEventListener('change', save);
+
+  disableBtn.addEventListener('click', () => {
+    input.value = '';
+    chrome.storage.sync.set({ refreshIntervalMinutes: 0 });
   });
+
+  if (chrome.tabs && chrome.tabs.query && chrome.tabs.sendMessage) {
+    const updateCountdown = () => {
+      chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+        const tab = tabs[0];
+        if (!tab) {
+          countdownEl.textContent = '';
+          return;
+        }
+        chrome.tabs.sendMessage(tab.id, { type: 'getRemaining' }, (resp) => {
+          if (resp && resp.refreshIntervalMinutes > 0 && resp.remainingMs > 0) {
+            const totalSeconds = Math.ceil(resp.remainingMs / 1000);
+            const minutes = Math.floor(totalSeconds / 60);
+            const seconds = totalSeconds % 60;
+            countdownEl.textContent = `Refreshing in ${minutes}:${seconds.toString().padStart(2, '0')}`;
+          } else {
+            countdownEl.textContent = '';
+          }
+        });
+      });
+    };
+
+    setInterval(updateCountdown, 1000);
+    updateCountdown();
+  }
 })();

--- a/popup.test.js
+++ b/popup.test.js
@@ -1,18 +1,18 @@
 const path = './popup.js';
 
 describe('popup', () => {
-  test('logs changes and queries tabs', () => {
-    document.body.innerHTML = '<form id="settings"><input name="foo" type="checkbox"></form>';
-    const query = jest.fn();
-    global.chrome = { tabs: { query } };
-    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  test('loads and saves refresh interval', () => {
+    document.body.innerHTML = '<form id="settings"><input id="refresh-interval" type="number"></form>';
+    const get = jest.fn((defaults, cb) => cb({ refreshIntervalMinutes: 5 }));
+    const set = jest.fn();
+    global.chrome = { storage: { sync: { get, set } } };
     require(path);
-    const input = document.querySelector('input');
-    input.checked = true;
-    input.dispatchEvent(new Event('change', { bubbles: true }));
-    expect(logSpy).toHaveBeenCalledWith('foo', true);
-    expect(query).toHaveBeenCalledWith({active: true, currentWindow: true}, expect.any(Function));
-    logSpy.mockRestore();
+    const input = document.getElementById('refresh-interval');
+    expect(get).toHaveBeenCalled();
+    expect(input.value).toBe('5');
+    input.value = '10';
+    input.dispatchEvent(new Event('change'));
+    expect(set).toHaveBeenCalledWith({ refreshIntervalMinutes: 10 });
     delete global.chrome;
   });
 });

--- a/popup.test.js
+++ b/popup.test.js
@@ -1,18 +1,26 @@
 const path = './popup.js';
 
 describe('popup', () => {
-  test('loads and saves refresh interval', () => {
-    document.body.innerHTML = '<form id="settings"><input id="refresh-interval" type="number"></form>';
+  test('handles refresh interval and disable button', () => {
+    document.body.innerHTML =
+      '<form id="settings">' +
+      '<input id="refresh-interval" type="number" placeholder="Not active"/>' +
+      '<button id="disable" type="button"></button>' +
+      '</form><p id="countdown"></p>';
     const get = jest.fn((defaults, cb) => cb({ refreshIntervalMinutes: 5 }));
     const set = jest.fn();
     global.chrome = { storage: { sync: { get, set } } };
     require(path);
     const input = document.getElementById('refresh-interval');
+    const disable = document.getElementById('disable');
     expect(get).toHaveBeenCalled();
     expect(input.value).toBe('5');
+    expect(input.placeholder).toBe('Not active');
     input.value = '10';
     input.dispatchEvent(new Event('change'));
     expect(set).toHaveBeenCalledWith({ refreshIntervalMinutes: 10 });
+    disable.click();
+    expect(set).toHaveBeenCalledWith({ refreshIntervalMinutes: 0 });
     delete global.chrome;
   });
 });


### PR DESCRIPTION
## Summary
- Reload pages after a period of inactivity with new auto_refresh content script
- Allow users to configure refresh interval in popup and persist via storage
- Extend manifest to include the new auto refresh functionality

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a99f7e8a34832f9b545e1929e0e09e