### PR TITLE
Make refresh interval per-tab and fix countdown

### DIFF
--- a/auto_refresh.js
+++ b/auto_refresh.js
@@ -1,5 +1,6 @@
 (() => {
-  const KEY = 'autoRefreshMinutes';
+  const KEY_INTERVAL = 'autoRefreshMinutes';
+  const KEY_NEXT = 'autoRefreshNextTime';
   let refreshIntervalMinutes = 0;
   let timeoutId;
   let nextRefreshTime = 0;
@@ -7,13 +8,15 @@
   const save = () => {
     if (refreshIntervalMinutes > 0) {
       try {
-        sessionStorage.setItem(KEY, String(refreshIntervalMinutes));
+        sessionStorage.setItem(KEY_INTERVAL, String(refreshIntervalMinutes));
+        sessionStorage.setItem(KEY_NEXT, String(nextRefreshTime));
       } catch (e) {
         // ignore
       }
     } else {
       try {
-        sessionStorage.removeItem(KEY);
+        sessionStorage.removeItem(KEY_INTERVAL);
+        sessionStorage.removeItem(KEY_NEXT);
       } catch (e) {
         // ignore
       }
@@ -32,16 +35,29 @@
     } else {
       nextRefreshTime = 0;
     }
+    save();
   };
 
   const load = () => {
     try {
-      const stored = sessionStorage.getItem(KEY);
-      refreshIntervalMinutes = stored ? parseInt(stored, 10) || 0 : 0;
+      const storedInterval = sessionStorage.getItem(KEY_INTERVAL);
+      refreshIntervalMinutes = storedInterval ? parseInt(storedInterval, 10) || 0 : 0;
+      const storedNext = sessionStorage.getItem(KEY_NEXT);
+      nextRefreshTime = storedNext ? parseInt(storedNext, 10) || 0 : 0;
     } catch (e) {
       refreshIntervalMinutes = 0;
+      nextRefreshTime = 0;
     }
-    resetTimer();
+    if (refreshIntervalMinutes > 0) {
+      const remaining = nextRefreshTime - Date.now();
+      if (remaining > 0) {
+        timeoutId = setTimeout(() => {
+          location.reload();
+        }, remaining);
+      } else {
+        resetTimer();
+      }
+    }
   };
 
   ['click', 'mousemove', 'keydown', 'scroll', 'touchstart'].forEach((event) => {
@@ -57,7 +73,6 @@
         });
       } else if (request.type === 'setInterval') {
         refreshIntervalMinutes = request.minutes || 0;
-        save();
         resetTimer();
         sendResponse({ success: true });
       } else if (request.type === 'getInterval') {


### PR DESCRIPTION
## Summary
- Store refresh interval in session storage and handle messaging per tab
- Query active tab to get/set refresh interval and show countdown
- Update tests for new popup messaging behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa78b8f700832fb5ef10066bc1e26b