### PR TITLE
Save refresh interval on popup close

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -17,6 +17,7 @@
   };
 
   input.addEventListener('change', save);
+  window.addEventListener('unload', save);
 
   disableBtn.addEventListener('click', () => {
     input.value = '';

--- a/popup.test.js
+++ b/popup.test.js
@@ -17,7 +17,7 @@ describe('popup', () => {
     expect(input.value).toBe('5');
     expect(input.placeholder).toBe('Not active');
     input.value = '10';
-    input.dispatchEvent(new Event('change'));
+    window.dispatchEvent(new Event('unload'));
     expect(set).toHaveBeenCalledWith({ refreshIntervalMinutes: 10 });
     disable.click();
     expect(set).toHaveBeenCalledWith({ refreshIntervalMinutes: 0 });


### PR DESCRIPTION
## Summary
- Revert per-tab refresh implementation to use global storage again
- Save the chosen refresh interval when the popup closes by listening for `unload`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa78b8f700832fb5ef10066bc1e26b